### PR TITLE
Fix monit on 42.2

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,10 +3,9 @@ FROM splatform/os-image-opensuse:42.2
 # Install RVM & Ruby 2.3.1
 RUN zypper -n in --force-resolution libopenssl-devel \
         && gpg --keyserver hkp://keys.gnupg.net --recv-keys 409B6B1796C275462A1703113804BB82D39DC0E3 \
-        && curl -sSL https://get.rvm.io | bash -s stable --ruby=2.3.1 \
+        && curl -sSL https://raw.githubusercontent.com/rvm/rvm/stable/binscripts/rvm-installer | bash -s stable --ruby=2.3.1 \
         && /bin/bash -c "source /usr/local/rvm/scripts/rvm && gem install bundler '--version=1.11.2' --no-format-executable" \
         && echo "source /usr/local/rvm/scripts/rvm" >> ~/.bashrc
-
 # Install dumb-init
 RUN wget -O /usr/bin/dumb-init https://github.com/Yelp/dumb-init/releases/download/v1.2.0/dumb-init_1.2.0_amd64 \
         && chmod +x /usr/bin/dumb-init

--- a/rsyslog_conf/etc/monit/templates/rootbin
+++ b/rsyslog_conf/etc/monit/templates/rootbin
@@ -1,0 +1,4 @@
+ if failed checksum       then unmonitor
+ if failed permission 755 then unmonitor
+ if failed uid root       then unmonitor
+ if failed gid root       then unmonitor


### PR DESCRIPTION
This PR adds the missing `/etc/monit/templates/rootbin` and switches to the stable installer of rvm (https://github.com/rvm/rvm/issues/4068)