### PR TITLE
Install vim

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -14,7 +14,7 @@ RUN wget -O /usr/bin/dumb-init https://github.com/Yelp/dumb-init/releases/downlo
 RUN /bin/bash -c "source /usr/local/rvm/scripts/rvm && gem install configgin"
 
 # Install additional dependencies
-RUN zypper -n in gettext-tools jq rsync
+RUN zypper -n in gettext-tools jq rsync vim
 
 ADD monitrc.erb /opt/hcf/monitrc.erb
 


### PR DESCRIPTION
This is required, ridiculously, because of
https://github.com/coreos/etcd/blob/e4561dd8cfb1/Godeps/_workspace/src/github.com/prometheus/procfs/fixtures/26231/exe

This does not appear to be an issue in etcd 3.x but we're not using that quite yet.