### PR TITLE
Support pinning the configgin version

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,5 @@
 ARG base_image=splatform/os-image-opensuse:42.2
+
 FROM ${base_image}
 
 # Install RVM & Ruby 2.3.1
@@ -12,7 +13,9 @@ RUN wget -O /usr/bin/dumb-init https://github.com/Yelp/dumb-init/releases/downlo
         && chmod +x /usr/bin/dumb-init
 
 # Install configgin
-RUN /bin/bash -c "source /usr/local/rvm/scripts/rvm && gem install configgin"
+# Putting this ARG to the top of the file mysteriously makes it always empty :|
+ARG configgin_version
+RUN /bin/bash -c "source /usr/local/rvm/scripts/rvm && gem install configgin ${configgin_version:+--version=${configgin_version}}"
 
 # Install additional dependencies
 RUN zypper -n in gettext-tools jq rsync

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,5 @@
-FROM splatform/os-image-opensuse:42.2
+ARG base_image=splatform/os-image-opensuse:42.2
+FROM ${base_image}
 
 # Install RVM & Ruby 2.3.1
 RUN zypper -n in --force-resolution libopenssl-devel \


### PR DESCRIPTION
This lets the builder to (optionally) provide a configgin version so that we can better reproduce things.

Also, this makes the base image configurable so that we can build SLE stemcells from the same repo.