### PR TITLE
Handle the os-image the same way as Fissile for SLE handles it

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,4 @@
-ARG base_image=splatform/os-image-opensuse:42.3-29.90.0
-
+ARG base_image
 FROM ${base_image}
 
 # Install RVM & Ruby 2.3.1


### PR DESCRIPTION
Use the latest image if no specific tag is specified.