### PR TITLE
Bump configgin from 0.18.4 to 0.18.5

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -19,7 +19,7 @@ RUN wget -O /usr/bin/dumb-init https://github.com/Yelp/dumb-init/releases/downlo
 
 # Install configgin
 # The configgin version is hardcoded here so a commit is generated when the version is bumped.
-RUN /bin/bash -c "source /usr/local/rvm/scripts/rvm && gem install configgin --version=0.18.4"
+RUN /bin/bash -c "source /usr/local/rvm/scripts/rvm && gem install configgin --version=0.18.5"
 
 # Install additional dependencies
 RUN zypper -n in jq rsync fuse


### PR DESCRIPTION
This pulls in code to restart pods when the properties they import change (so that they can pick up the new properties).

See also:
https://github.com/cloudfoundry-incubator/configgin/pull/97
https://github.com/cloudfoundry-incubator/fissile/pull/470