### PR TITLE
Bump configgin from 0.18.6 to 0.18.7

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -19,7 +19,7 @@ RUN wget -O /usr/bin/dumb-init https://github.com/Yelp/dumb-init/releases/downlo
 
 # Install configgin
 # The configgin version is hardcoded here so a commit is generated when the version is bumped.
-RUN /bin/bash -c "source /usr/local/rvm/scripts/rvm && gem install configgin --version=0.18.6"
+RUN /bin/bash -c "source /usr/local/rvm/scripts/rvm && gem install configgin --version=0.18.7"
 
 # Install additional dependencies
 RUN zypper -n in jq rsync fuse


### PR DESCRIPTION
Ref: https://trello.com/c/edcUo2BW/1063-autoscaler-broken-on-jenkins-too-long-a-name-for-a-property

The `skiff-import-properties` prefix for pod restart is shortened to `skiff-in-props` to give more space to role and job names added after it, less chance of hitting kube's limit of 63 characters.