### PR TITLE
Bump configgin from 0.18.8 to 0.19.0

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -19,7 +19,7 @@ RUN wget -O /usr/bin/dumb-init https://github.com/Yelp/dumb-init/releases/downlo
 
 # Install configgin
 # The configgin version is hardcoded here so a commit is generated when the version is bumped.
-RUN /bin/bash -c "source /usr/local/rvm/scripts/rvm && gem install configgin --version=0.18.8"
+RUN /bin/bash -c "source /usr/local/rvm/scripts/rvm && gem install configgin --version=0.19.0"
 
 # Install additional dependencies
 RUN zypper -n in jq rsync fuse


### PR DESCRIPTION
The change moves the exported bosh properties from pod annotations to secrets, so they are no longer visible to everyone who get display the pod objects.

[jsc#CAP-761]